### PR TITLE
Get useful tweet

### DIFF
--- a/lib/ruboty/handlers/twitter_search.rb
+++ b/lib/ruboty/handlers/twitter_search.rb
@@ -21,7 +21,9 @@ module Ruboty
 
       # @return [true] to prevent running missing handlers.
       def search(message)
-        statuses = client.search(message[:query], since_id: fetch_since_id_for(message[:query])).take(10)
+        message = Message.parse(message[:query])
+        # http://www.rubydoc.info/gems/twitter/Twitter/REST/Search#search-instance_method
+        statuses = client.search(message.word, since_id: fetch_since_id_for(message.since_id)).take(10)
         if statuses.any?
           message.reply(StatusesView.new(statuses).to_s)
           store_since_id(query: message[:query], since_id: statuses.first.id)
@@ -82,6 +84,36 @@ module Ruboty
             "https://twitter.com/#{status.user.screen_name}/status/#{status.id}"
           end
         end
+      end
+    end
+
+    class Message
+      DELIMITER = ' '
+
+      def self.parse(query)
+        return self.new({'word' => query}) if query.split(DELIMITER).size == 1
+        options = JSON.parse("{#{query.gsub(/(\w+):(\w+)/, '"\1":"\2",').chomp(',')}}") # go bold
+        self.new(options)
+      end
+
+      def initialize(options)
+        @options = options
+      end
+
+      def word
+        @options['word']
+      end
+
+      def since_id
+        @options['since_id']
+      end
+
+      def retweet
+        @options['retweet']
+      end
+
+      def fav
+        @options['fav']
       end
     end
   end


### PR DESCRIPTION
I want to get more useful tweet by counting retweets,favs and using twitter api `result_type` param.

When query is specified with `key:val` format, ruboty-twitter_search applies query.

```
> ruboty search twitter by word:lovelive result_type:popular fav:10
https://twitter.com/GSC_GUMA/status/577666197530914816
https://twitter.com/nico_nico_info/status/579249886471684096
https://twitter.com/hulu_japan/status/578496209846824961
https://twitter.com/hulu_japan/status/578481256859508736
https://twitter.com/xxxskri/status/580101656739586048
https://twitter.com/NISMO_JP/status/580298424265801728
```

Also accept traditional format.

```
> ruboty search twitter by lovelive
https://twitter.com/loveliveantena/status/580406825503338497
https://twitter.com/loveliveantena/status/580406828003155968
https://twitter.com/A_RISE_lovelive/status/580406828103831552
https://twitter.com/A_RISE_lovelive/status/580406829118783488
https://twitter.com/loveliveantena/status/580406831396339712
https://twitter.com/sinji_lovelive/status/580406842846777346
https://twitter.com/lovelive_lily/status/580406859938533376
https://twitter.com/RinHoshizora3/status/580406950929764353
https://twitter.com/lovelive_mtm_1/status/580406979606261760
https://twitter.com/lovelive_trend/status/580406982814863360
```

I'm looking forward to your refactoring :stuck_out_tongue: 
